### PR TITLE
Change Health Endpoint to /health

### DIFF
--- a/src/SFA.DAS.ProviderRegistrations.Api/Startup.cs
+++ b/src/SFA.DAS.ProviderRegistrations.Api/Startup.cs
@@ -54,7 +54,7 @@ namespace SFA.DAS.ProviderRegistrations.Api
 
             app.UseHttpsRedirection();
             app.UseMvc();
-            app.UseHealthChecks("/health-check");
+            app.UseHealthChecks("/health");
         }
 
         public void ConfigureContainer(Registry registry)

--- a/src/SFA.DAS.ProviderRegistrations.Web/Startup.cs
+++ b/src/SFA.DAS.ProviderRegistrations.Web/Startup.cs
@@ -90,7 +90,7 @@ namespace SFA.DAS.ProviderRegistrations.Web
                 .UseCookiePolicy()
                 .UseAuthentication()
                 .UseMvc()
-                .UseHealthChecks("/health-check");
+                .UseHealthChecks("/health");
 
             var logger = loggerFactory.CreateLogger(nameof(Startup));
             logger.Log(LogLevel.Information, "Application start up configure is complete");


### PR DESCRIPTION
Changed the health endpoint from `/health-check` to `/health` to be consistent with other endpoints in the App Gateway configurations.