### PR TITLE
FAI-891 Provider Registration DfESignIn Integration

### DIFF
--- a/src/SFA.DAS.ProviderRegistrations.Web/Authentication/CustomServiceRole.cs
+++ b/src/SFA.DAS.ProviderRegistrations.Web/Authentication/CustomServiceRole.cs
@@ -1,0 +1,12 @@
+﻿using SFA.DAS.DfESignIn.Auth.Constants;
+using SFA.DAS.DfESignIn.Auth.Enums;
+using SFA.DAS.DfESignIn.Auth.Interfaces;
+
+namespace SFA.DAS.ProviderRegistrations.Web.Authentication
+{
+    public class CustomServiceRole : ICustomServiceRole
+    {
+        public string RoleClaimType => CustomClaimsIdentity.Service;
+        public CustomServiceRoleValueType RoleValueType => CustomServiceRoleValueType.Code;
+    }
+}

--- a/src/SFA.DAS.ProviderRegistrations.Web/Program.cs
+++ b/src/SFA.DAS.ProviderRegistrations.Web/Program.cs
@@ -23,7 +23,11 @@ namespace SFA.DAS.ProviderRegistrations.Web
                     {
                         config.AddAzureTableStorage(options =>
                             {
-                                options.ConfigurationKeys = ProviderRegistrationsConfigurationKeys.ProviderRegistrations.Split(',');
+                                options.ConfigurationKeys = new[]
+                                {
+                                    ProviderRegistrationsConfigurationKeys.ProviderRegistrations,
+                                    ProviderRegistrationsConfigurationKeys.DfEOidcConfiguration
+                                };
                                 options.PreFixConfigurationKeys = false;
                             });
                     })

--- a/src/SFA.DAS.ProviderRegistrations.Web/SFA.DAS.ProviderRegistrations.Web.csproj
+++ b/src/SFA.DAS.ProviderRegistrations.Web/SFA.DAS.ProviderRegistrations.Web.csproj
@@ -15,16 +15,21 @@
     <PackageReference Include="AutoMapper" Version="9.0.0" />
     <PackageReference Include="MediatR" Version="7.0.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.18.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="3.1.32" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.WsFederation" Version="3.1.20" />
     <PackageReference Include="Microsoft.AspNetCore.DataProtection.StackExchangeRedis" Version="3.1.20" />
+    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="6.22.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="NLog.Web.AspNetCore" Version="4.14.0" />
     <PackageReference Include="SFA.DAS.Authorization.Mvc" Version="5.6.7" />
     <PackageReference Include="SFA.DAS.Configuration.AzureTableStorage" Version="3.0.84" />
+    <PackageReference Include="SFA.DAS.DfESignIn.Auth" Version="17.1.53" />
     <PackageReference Include="SFA.DAS.NLog.Targets.Redis" Version="1.2.1" />
     <PackageReference Include="SFA.DAS.Provider.Shared.UI" Version="2.0.24" />
     <PackageReference Include="SFA.DAS.ProviderUrlHelper" Version="1.1.749" />
     <PackageReference Include="structuremap" Version="4.7.1" />
     <PackageReference Include="StructureMap.AspNetCore" Version="2.0.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.22.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SFA.DAS.ProviderRegistrations/Configuration/ProviderRegistrationsConfigurationKeys.cs
+++ b/src/SFA.DAS.ProviderRegistrations/Configuration/ProviderRegistrationsConfigurationKeys.cs
@@ -12,5 +12,6 @@
         public static string RedisConnectionSettings = "RedisConnectionSettings";
         public static string RoatpApiClientSettings ="RoatpApiClientSettings";
         public const string UseDfESignIn = "UseDfESignIn";
+        public const string DfEOidcConfiguration = "SFA.DAS.Provider.DfeSignIn";
     }
 }


### PR DESCRIPTION
Commit Details:
Integration of DfESignIn OpenID Connect with the Provider Registrations service
Extending Service Extension to add DfESignIn Configuration. NuGet Package upgrade required to adapt the above changes.

Story link: https://skillsfundingagency.atlassian.net/browse/FAI-891

![screencapture-localhost-5001-10000528-registration-startaccountsetup-2023-07-20-13_53_09](https://github.com/SkillsFundingAgency/das-provider-registrations/assets/2102434/992822c9-0d97-45c1-9a48-8d7c26056065)
